### PR TITLE
Added a test to wait finishing the perf process

### DIFF
--- a/test/test_performance.py.in
+++ b/test/test_performance.py.in
@@ -90,6 +90,13 @@ def generate_test_description():
     ]), locals()
 
 
+class TestTerminatingProcessStops(unittest.TestCase):
+
+    def test_proc_terminates(self, proc_output, proc_info, node_under_test, performance_log_prefix):
+        proc_output.assertWaitFor("Maximum runtime reached. Exiting.",
+                                   process=node_under_test, timeout=60)
+
+
 @launch_testing.post_shutdown_test()
 class PerformanceTestResults(unittest.TestCase):
 


### PR DESCRIPTION
Avoiding this error when launching tests:

```bash
Task exception was never retrieved
future: <Task finished coro=<LaunchService._process_one_event() done, defined at /opt/ros/eloquent/lib/python3.6/site-packages/launch/launch_service.py:289> exception=RuntimeError('Signal event received before subprocess transport available.',)>
Traceback (most recent call last):
  File "/opt/ros/eloquent/lib/python3.6/site-packages/launch/launch_service.py", line 291, in _process_one_event
    await self.__process_event(next_event)
  File "/opt/ros/eloquent/lib/python3.6/site-packages/launch/launch_service.py", line 311, in __process_event
    visit_all_entities_and_collect_futures(entity, self.__context))
  File "/opt/ros/eloquent/lib/python3.6/site-packages/launch/utilities/visit_all_entities_and_collect_futures_impl.py", line 38, in visit_all_entities_and_collect_futures
    sub_entities = entity.visit(context)
  File "/opt/ros/eloquent/lib/python3.6/site-packages/launch/action.py", line 108, in visit
    return self.execute(context)
  File "/opt/ros/eloquent/lib/python3.6/site-packages/launch/actions/opaque_function.py", line 75, in execute
    return self.__function(context, *self.__args, **self.__kwargs)
  File "/opt/ros/eloquent/lib/python3.6/site-packages/launch/actions/execute_process.py", line 383, in __on_signal_process_event
    raise RuntimeError('Signal event received before subprocess transport available.')
RuntimeError: Signal event received before subprocess transport available.
```